### PR TITLE
Update actions/checkout to latest released version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Checkout tree
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Check for changes in changelog


### PR DESCRIPTION
Fixes the "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24" error