### PR TITLE
Pin `actions/checkout` to SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Checkout tree
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Check for changes in changelog


### PR DESCRIPTION
For organizations to be able to enable "[Require actions to be pinned to a full-length commit SHA](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)" all of their GHAs need to be transitively pinned

Meaning that if an organization wants to use this setting, they will not be able to use `tarides/changelog-check-action` unless its actions are also pinned

Reference: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions