### PR TITLE
Add config for multiple labels to skip check

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,22 @@ Not all changes need a changelog entry, some are not user-visible, like
 changing CI or some internal refactoring. For those it is possible to disable
 the check.
 
-To do so, create a new label called `no changelog` and apply it to the PR. Then
-the changelog check will re-run and succeed automatically. This label can also
-be applied directly when opening the PR so the check will be automatically
-omitted.
+To do so, decide on a label to apply to these PRs. By default the action uses
+`no changelog`, but it can be any label, or even multiple ones. Then apply the
+label to the PR in question which will re-run the check and pass successfully
+this time. This label can also be applied directly when opening the PR so the
+check will be automatically omitted.
 
-## Options
+## Inputs
 
 The file that is being checked by default is called `CHANGES.md` but you can
 use the `changelog` argument to specify any other file as well.
+
+| Key           | Meaning                                                             | Default value       |
+| ------------- | ------------------------------------------------------------------- | ------------------- |
+| `changelog`   | file that is checked for changes                                    | `CHANGES.md`        |
+| `labels`      | semicolon separated list of labels which trigger skipping the check | `no changelog`      |
+
 
 ## Set up
 
@@ -41,7 +48,7 @@ Add this to your GitHub workflow:
 
 ```yaml
 - name: Check changelog
-  uses: tarides/changelog-check-action@v2
+  uses: tarides/changelog-check-action@v4
 ```
 
 ### Full example
@@ -58,9 +65,10 @@ on:
 jobs:
   Check-Changelog:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: tarides/changelog-check-action@v2
+      - uses: tarides/changelog-check-action@v4
         with:
           changelog: CHANGES.md
+          labels: "no changelog"
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,16 +8,21 @@ inputs:
     description: Which file to use for checking that the changelog was modified
     required: false
     default: CHANGES.md
+  labels:
+    description: The labels (semicolon separated) that allow a PR to pass without modifying the changelog
+    required: false
+    default: "no changelog"
 runs:
   using: composite
   steps:
     - name: Checkout tree
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Check for changes in changelog
-      env:
-        BASE_REF: ${{ github.event.pull_request.base.ref }}
-        NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
       run: |
         git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "+${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" --quiet
-        ${{ github.action_path }}/check.sh "${{ inputs.changelog }}"
+        ${{ github.action_path }}/check.sh \
+        --base-ref "${{ github.event.pull_request.base.ref }}" \
+        --changelog-file "${{ inputs.changelog}}" \
+        --labels-to-skip "${{ inputs.labels }}" \
+        --labels-set "${{ join(github.even.pull_request.labels.*.name, ';') }}"
       shell: bash

--- a/check.sh
+++ b/check.sh
@@ -2,18 +2,59 @@
 
 set -uo pipefail
 
-CHANGELOG_FILE="${1:-CHANGES.md}"
+if ! valid_args=$(getopt -o h --long base-ref:,labels-set:,labels-to-skip:,changelog-file: -- "$@") ; then
+  exit 1
+fi
+eval set -- "$valid_args"
 
-if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
-    # 'no changelog' set, so finish successfully
-    exit 0
-else
-    # a changelog check is required
-    # fail if the diff is empty
-    if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
-        echo >&2 "User-visible changes should come with an entry in the changelog. This behavior
-can be overridden by using the \"no changelog\" label, which is used for changes
-that are not user-visible."
-        exit 1
+while true; do
+  case "$1" in
+    --base-ref)
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --changelog-file)
+      CHANGELOG_FILE="$2"
+      shift 2
+      ;;
+    --labels-to-skip)
+      readarray -d ';' -t labels_to_skip < <( echo -n "$2" )
+      shift 2
+      ;;
+    --labels-set)
+      readarray -d ';' -t labels_set < <( echo -n "$2" )
+      shift 2
+      ;;
+    -h)
+      echo "Usage: ./check.sh --base-ref <ref-name> --labels-set <semicolon-separated-list> --labels-to-skip <semicolon-separated-list> --changelog-file <filename>"
+      shift
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+  esac
+done
+
+for skip_label in "${labels_to_skip[@]}"
+do
+  for supplied_label in "${labels_set[@]}"
+  do
+    if [[ "$supplied_label" == "$skip_label" ]]; then
+      # one of the labels to skip was set
+      exit 0
     fi
+  done
+done
+
+# a changelog check is required
+# fail if the diff is empty
+if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
+  skip_labels=$(printf ", '%s'" "${labels_to_skip[@]}")
+  skip_labels=${skip_labels:1}
+    echo >&2 "User-visible changes should come with an entry in the changelog. This behavior
+can be overridden by using one of$skip_labels labels, which is used for changes
+that are not user-visible."
+    exit 1
 fi


### PR DESCRIPTION
This is a different take on #11. I didn't like to move a whole lot of logic out of the shell script into a YAML file. That makes it harder to maintain and test, so this PR goes in the opposite direction and moves most logic into the shell script instead (which also allows it to be `shellcheck`'d).

It updates the `README` as well with information about the configuration options.

Closes #11