### PR TITLE
Improve the checkout speed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,11 @@ runs:
   steps:
     - name: Checkout tree
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 0
     - name: Check for changes in changelog
       env:
         BASE_REF: ${{ github.event.pull_request.base.ref }}
         NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
-      run: ${{ github.action_path }}/check.sh "${{ inputs.changelog }}"
+      run: |
+        git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin "+${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" --quiet
+        ${{ github.action_path }}/check.sh "${{ inputs.changelog }}"
       shell: bash


### PR DESCRIPTION
This PR speeds up checkout of repositories. `fetch-depth` clones the whole repository is not necessary and slow on large repositories.

We needed `fetch-depth` to be able to compute the diff between the PR base ref and the PR, but we don't need to clone all branches or all history. As such we switch to shallow fetches again and then specifically fetch the base ref.