### PR TITLE
Update README to recommend `ubuntu-slim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ on:
 jobs:
   Check-Changelog:
     name: Check Changelog Action
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
       - uses: tarides/changelog-check-action@v4
         with:


### PR DESCRIPTION
Tested it on `ubuntu-slim` and it works fine. We don't have many dependencies so this is unlikely to break in the future. Picked up the suggestion from @smorimoto.

Closes #7.